### PR TITLE
Fix async session retrieval

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const { title } = Astro.props;
-const user = getCurrentUser(Astro);
+const user = await getCurrentUser(Astro);
 ---
 
 <!doctype html>

--- a/src/lib/getCurrentUser.ts
+++ b/src/lib/getCurrentUser.ts
@@ -1,8 +1,9 @@
 import { getSession, getSessionIdFromCookie } from "./auth";
 
-export function getCurrentUser(Astro: Astro): string | null {
+export async function getCurrentUser(Astro: Astro): Promise<string | null> {
   const cookie = Astro.request.headers.get("cookie") || undefined;
   const sessionId = getSessionIdFromCookie(cookie);
   if (!sessionId) return null;
-  return getSession(sessionId) || null;
+  const username = await getSession(sessionId);
+  return username || null;
 }

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -10,7 +10,7 @@ export const GET: APIRoute = async ({ request }) => {
       headers: { "Content-Type": "application/json" },
     });
   }
-  const username = getSession(sessionId);
+  const username = await getSession(sessionId);
   if (!username) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {
       status: 401,

--- a/src/pages/api/auth/setup.ts
+++ b/src/pages/api/auth/setup.ts
@@ -43,7 +43,7 @@ export const POST: APIRoute = async ({ request }) => {
     await addUser(user);
 
     // Create session and set cookie
-    const sessionId = createSession(username);
+    const sessionId = await createSession(username);
 
     // Handle swarm setup (still mock for now)
     let swarmMessage = "";

--- a/src/pages/api/auth/update.ts
+++ b/src/pages/api/auth/update.ts
@@ -18,7 +18,7 @@ export const POST: APIRoute = async ({ request }) => {
       },
     );
   }
-  const currentUsername = getSession(sessionId);
+  const currentUsername = await getSession(sessionId);
   if (!currentUsername) {
     return new Response(
       JSON.stringify({ success: false, message: "Unauthorized" }),


### PR DESCRIPTION
## Summary
- ensure getCurrentUser awaits sessions
- make Layout.astro handle async user lookup
- fix async session reads in auth API routes

## Testing
- `npx biome format --write src`
- `npx biome check src`


------
https://chatgpt.com/codex/tasks/task_b_68416cb1072083328221d1b64552b630